### PR TITLE
Statement in base_urls options

### DIFF
--- a/src/Bridge/Nette/DI/AssetExtension.php
+++ b/src/Bridge/Nette/DI/AssetExtension.php
@@ -39,7 +39,7 @@ final class AssetExtension extends CompilerExtension
 		$packageStructure = Expect::structure([
 			'base_path' => Expect::string()
 				->nullable(),
-			'base_urls' => Expect::anyOf(Expect::string(), Expect::listOf('string'))
+			'base_urls' => Expect::anyOf(Expect::type(Statement::class), Expect::string(), Expect::listOf('string|' . Statement::class))
 				->default([])
 				->before(static fn ($val): array => !is_array($val) ? [$val] : $val),
 			'version' => Expect::anyOf(Expect::string(), Expect::int(), Expect::float())
@@ -61,7 +61,7 @@ final class AssetExtension extends CompilerExtension
 
 		return Expect::structure([
 			'base_path' => Expect::string(''),
-			'base_urls' => Expect::anyOf(Expect::string(), Expect::listOf('string'))
+			'base_urls' => Expect::anyOf(Expect::type(Statement::class), Expect::string(), Expect::listOf('string|' . Statement::class))
 				->default([])
 				->before(static fn ($val): array => !is_array($val) ? [$val] : $val),
 			'version' => Expect::anyOf(Expect::string(), Expect::int(), Expect::float())

--- a/tests/Bridge/Nette/DI/fullFeatured.neon
+++ b/tests/Bridge/Nette/DI/fullFeatured.neon
@@ -19,7 +19,7 @@ asset:
 			version_format: '%%s-%%s'
 		bar:
 			base_urls:
-				- https://bar2.example.com
+				- ::implode('', ['https://', 'bar2.example', '.com'])
 		bar_version_strategy:
 			base_urls:
 				- https://bar_version_strategy.example.com


### PR DESCRIPTION
Nette\DI\Definitions\Statement is now acceptable type for option `base_urls` and `packages[].base_urls`
